### PR TITLE
Merchant method move

### DIFF
--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -8,7 +8,7 @@ class Merchant
 
   def self.create_merchant(attributes)
     data_hash = {}
-    require "pry"; binding.pry
+    #require "pry"; binding.pry
     data_hash[:id] = @repo.next_highest_merchant_id
     data_hash[:name] = attributes[:name]
     new(data_hash, @repo)

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -6,12 +6,12 @@ class Merchant
     @repo = repo
   end
 
-  def self.create_merchant(attributes)
+  def self.create_merchant(attributes, merchant_repo)
     data_hash = {}
     #require "pry"; binding.pry
-    data_hash[:id] = @repo.next_highest_merchant_id
+    data_hash[:id] = merchant_repo.next_highest_merchant_id
     data_hash[:name] = attributes[:name]
-    new(data_hash, @repo)
+    new(data_hash, merchant_repo)
   end
 
   def update_merchant(id, attributes)

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -14,7 +14,7 @@ class Merchant
     new(data_hash, merchant_repo)
   end
 
-  def update_merchant(id, attributes)
+  def update_merchant(attributes)
     @name = attributes[:name]
   end
 end

--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -5,4 +5,16 @@ class Merchant
     @name = data[:name]
     @repo = repo
   end
+
+  def self.create_merchant(attributes)
+    data_hash = {}
+    require "pry"; binding.pry
+    data_hash[:id] = @repo.next_highest_merchant_id
+    data_hash[:name] = attributes[:name]
+    new(data_hash, @repo)
+  end
+
+  def update_merchant(id, attributes)
+    @name = attributes[:name]
+  end
 end

--- a/spec/merchant_spec.rb
+++ b/spec/merchant_spec.rb
@@ -6,8 +6,8 @@ require 'csv'
 RSpec.describe do
   before(:each) do
     @data = {id: 5, name: 'Turing'}
-    # @repo = double('repo')
-    @repo = MerchantRepository.new('./spec/fixtures/mock_merchants.csv')
+    @repo = double('repo')
+    # @repo = MerchantRepository.new('./spec/fixtures/mock_merchants.csv')
     @merchant = Merchant.new(@data, @repo)
   end
   it 'exists' do
@@ -19,10 +19,10 @@ RSpec.describe do
     expect(@merchant.name).to eq('Turing')
   end
 
-  xit 'can create new merchants' do
+  it 'can create new merchants' do
     # allow(@merchant).to receive(:repo.next_highest_merchant_id).and_return(6)
     allow(@repo).to receive(:next_highest_merchant_id).and_return(6)
-    expect(Merchant.create_merchant({name: 'Marla'})).to be_a(Merchant)
+    expect(Merchant.create_merchant({name: 'Marla'}, @repo)).to be_a(Merchant)
   end
 
   it 'can update old merchants' do

--- a/spec/merchant_spec.rb
+++ b/spec/merchant_spec.rb
@@ -1,22 +1,34 @@
 require_relative 'spec_helper'
 require_relative '../lib/merchant'
+require_relative '../lib/merchant_repository'
 require 'csv'
 
 RSpec.describe do
+  before(:each) do
+    @data = {id: 5, name: 'Turing'}
+    # @repo = double('repo')
+    @repo = MerchantRepository.new('./spec/fixtures/mock_merchants.csv')
+    @merchant = Merchant.new(@data, @repo)
+  end
   it 'exists' do
-    data = {id: 5, name: 'Turing'}
-    repo = double('merchant repo')
-    merchant = Merchant.new(data, repo)
-
-    expect(merchant).to be_a Merchant
+    expect(@merchant).to be_a Merchant
   end
 
   it 'has attributes' do
-    data = {id: 5, name: 'Turing'}
-    repo = double('merchant repo')
-    merchant = Merchant.new(data, repo)
-
-    expect(merchant.id).to eq(5)
-    expect(merchant.name).to eq('Turing')
+    expect(@merchant.id).to eq(5)
+    expect(@merchant.name).to eq('Turing')
   end
+
+  xit 'can create new merchants' do
+    # allow(@merchant).to receive(:repo.next_highest_merchant_id).and_return(6)
+    allow(@repo).to receive(:next_highest_merchant_id).and_return(6)
+    expect(Merchant.create_merchant({name: 'Marla'})).to be_a(Merchant)
+  end
+
+  it 'can update old merchants' do
+    @merchant.update_merchant(5, {name: 'New Turing'})
+    expect(@merchant.id).to eq(5)
+    expect(@merchant.name).to eq('New Turing')
+  end
+
 end

--- a/spec/merchant_spec.rb
+++ b/spec/merchant_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe do
   end
 
   it 'can update old merchants' do
-    @merchant.update_merchant(5, {name: 'New Turing'})
+    @merchant.update_merchant({name: 'New Turing'})
     expect(@merchant.id).to eq(5)
     expect(@merchant.name).to eq('New Turing')
   end


### PR DESCRIPTION
Type of Change:
- bug fix

What does it implement:
- moved create and update methods to the merchant class 
- created tests for create and update. 

Any relevant logs, error outputs, etc.:
-create method still doesn't pass... don't know how to make it pass... so currently skipped. Should pass within the new MerchantRepository class though. (comment below, this was fixed on later push)